### PR TITLE
Major spring version upgrade 2.5.6

### DIFF
--- a/emis-client-v1/pom.xml
+++ b/emis-client-v1/pom.xml
@@ -3,11 +3,11 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>8.0.28</version>
+    <version>9.0.0</version>
     <relativePath/>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <version>2.0.5-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <groupId>gov.va.api.lighthouse</groupId>
   <artifactId>emis-client-v1</artifactId>
   <dependencies>

--- a/emis-client-v2/pom.xml
+++ b/emis-client-v2/pom.xml
@@ -3,11 +3,11 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>8.0.28</version>
+    <version>9.0.0</version>
     <relativePath/>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <version>2.0.5-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <groupId>gov.va.api.lighthouse</groupId>
   <artifactId>emis-client-v2</artifactId>
   <dependencies>

--- a/emis-model/pom.xml
+++ b/emis-model/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>api-starter</artifactId>
-    <version>8.0.28</version>
+    <version>9.0.0</version>
     <relativePath/>
   </parent>
   <groupId>gov.va.api.lighthouse</groupId>
   <artifactId>emis-model</artifactId>
-  <version>2.0.5-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
     <checkstyle.skip>true</checkstyle.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>8.0.28</version>
+    <version>9.0.0</version>
   </parent>
   <groupId>gov.va.api.lighthouse</groupId>
   <artifactId>emis-parent</artifactId>
-  <version>2.0.5-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>emis-model</module>


### PR DESCRIPTION
Parent major version upgrade.
Spring version change: 2.5.0 to 2.5.6.

Related to: department-of-veterans-affairs/health-apis-parent#115