### PR TITLE
API-000 Isolate SSL Context

### DIFF
--- a/emis-client/src/main/java/gov/va/api/lighthouse/emis/EmisClientConfig.java
+++ b/emis-client/src/main/java/gov/va/api/lighthouse/emis/EmisClientConfig.java
@@ -42,6 +42,16 @@ public class EmisClientConfig {
   @NoArgsConstructor
   @AllArgsConstructor
   @Accessors(fluent = false)
+  public static class TrustStore {
+    private String path;
+    private String password;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Accessors(fluent = false)
   public static class Service {
     private String url;
 
@@ -57,5 +67,7 @@ public class EmisClientConfig {
     @Builder.Default private boolean enabled = true;
 
     private KeyStore keyStore;
+
+    private TrustStore trustStore;
   }
 }


### PR DESCRIPTION
This PR moves to isolate the configured SSL Context within the `port` method.

```
      if (sslContext.isPresent()) {
        ((BindingProvider) port)
            .getRequestContext()
            .put(
                "com.sun.xml.ws.transport.https.client.SSLSocketFactory",
                sslContext.get().getSocketFactory());
      }
```

Rather than the default method
`HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());`