### PR TITLE
Api 23234 request logging

### DIFF
--- a/emis-client/src/main/java/gov/va/api/lighthouse/emis/SoapEmisClient.java
+++ b/emis-client/src/main/java/gov/va/api/lighthouse/emis/SoapEmisClient.java
@@ -9,7 +9,6 @@ import gov.va.viers.cdi.emis.requestresponse.v1.InputEdiPiOrIcn;
 import gov.va.viers.cdi.emis.requestresponse.v2.EMISdeploymentResponseType;
 import gov.va.viers.cdi.emis.requestresponse.v2.EMISguardReserveServicePeriodsResponseType;
 import gov.va.viers.cdi.emis.requestresponse.v2.EMISserviceEpisodeResponseType;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.KeyStore;
@@ -21,7 +20,6 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 import javax.xml.ws.BindingProvider;
-
 import lombok.Builder;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -30,253 +28,244 @@ import org.springframework.util.ResourceUtils;
 
 @Slf4j
 public class SoapEmisClient implements EmisClient {
-    private final Optional<SSLContext> sslContext;
+  private final Optional<SSLContext> sslContext;
 
-    private final EmisClientConfig config;
+  private final EmisClientConfig config;
 
-    /**
-     * Inspect the deployment message before it is sent.
-     */
-    private final Consumer<InputEdiPiOrIcn> deploymentRequestInspector;
+  /** Inspect the deployment message before it is sent. */
+  private final Consumer<gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn>
+      deploymentRequestInspector;
 
-    /**
-     * Inspect the deployment message after it is received.
-     */
-    private final Consumer<EMISdeploymentResponseType> deploymentResponseInspector;
+  /** Inspect the deployment message after it is received. */
+  private final Consumer<EMISdeploymentResponseType> deploymentResponseInspector;
 
-    /**
-     * Inspect the guardReserveService message before it is sent.
-     */
-    private final Consumer<InputEdiPiOrIcn> guardReserveServiceRequestInspector;
+  /** Inspect the guardReserveService message before it is sent. */
+  private final Consumer<gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn>
+      guardReserveServiceRequestInspector;
 
-    /**
-     * Inspect the guardReserveService message after it is received.
-     */
-    private final Consumer<EMISguardReserveServicePeriodsResponseType> guardReserveServiceResponseInspector;
+  /** Inspect the guardReserveService message after it is received. */
+  private final Consumer<EMISguardReserveServicePeriodsResponseType>
+      guardReserveServiceResponseInspector;
 
-    /**
-     * Inspect the militaryInformationServiceV2Health message after it is received.
-     */
-    private final Consumer<String> militaryInformationServiceV2HealthResponseInspector;
+  /** Inspect the serviceEpisodes message before it is sent. */
+  private final Consumer<gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn>
+      serviceEpisodesRequestInspector;
 
-    /**
-     * Inspect the serviceEpisodes message before it is sent.
-     */
-    private final Consumer<InputEdiPiOrIcn> serviceEpisodesRequestInspector;
+  /** Inspect the serviceEpisodes message after it is received. */
+  private final Consumer<EMISserviceEpisodeResponseType> serviceEpisodesResponseInspector;
 
-    /**
-     * Inspect the serviceEpisodes message after it is received.
-     */
-    private final Consumer<EMISserviceEpisodeResponseType> serviceEpisodesResponseInspector;
+  /** Inspect the veteranStatus message before it is sent. */
+  private final Consumer<InputEdiPiOrIcn> veteranStatusRequestInspector;
 
-    /**
-     * Inspect the veteranStatus message before it is sent.
-     */
-    private final Consumer<InputEdiPiOrIcn> veteranStatusRequestInspector;
+  /** Inspect the veteranStatus message after it is received. */
+  private final Consumer<EMISveteranStatusResponseType> veteranStatusResponseInspector;
 
-    /**
-     * Inspect the veteranStatus message after it is received.
-     */
-    private final Consumer<EMISveteranStatusResponseType> veteranStatusResponseInspector;
+  @Builder
+  private SoapEmisClient(
+      EmisClientConfig config,
+      Consumer<gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn> deploymentRequestInspector,
+      Consumer<EMISdeploymentResponseType> deploymentResponseInspector,
+      Consumer<gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn>
+          guardReserveServiceRequestInspector,
+      Consumer<EMISguardReserveServicePeriodsResponseType> guardReserveServiceResponseInspector,
+      Consumer<gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn>
+          serviceEpisodesRequestInspector,
+      Consumer<EMISserviceEpisodeResponseType> serviceEpisodesResponseInspector,
+      Consumer<InputEdiPiOrIcn> veteranStatusRequestInspector,
+      Consumer<EMISveteranStatusResponseType> veteranStatusResponseInspector) {
 
-    /**
-     * Inspect the veteranStatusServiceV1Health message after it is received.
-     */
-    private final Consumer<String> veteranStatusServiceV1HealthInspector;
+    this.deploymentRequestInspector = doNothingUnlessSet(deploymentRequestInspector);
+    this.deploymentResponseInspector = doNothingUnlessSet(deploymentResponseInspector);
+    this.guardReserveServiceRequestInspector =
+        doNothingUnlessSet(guardReserveServiceRequestInspector);
+    this.guardReserveServiceResponseInspector =
+        doNothingUnlessSet(guardReserveServiceResponseInspector);
+    this.serviceEpisodesRequestInspector = doNothingUnlessSet(serviceEpisodesRequestInspector);
+    this.serviceEpisodesResponseInspector = doNothingUnlessSet(serviceEpisodesResponseInspector);
+    this.veteranStatusRequestInspector = doNothingUnlessSet(veteranStatusRequestInspector);
+    this.veteranStatusResponseInspector = doNothingUnlessSet(veteranStatusResponseInspector);
 
-    @Builder
-    private SoapEmisClient(
-        EmisClientConfig config,
-        Consumer<InputEdiPiOrIcn> deploymentRequestInspector,
-        Consumer<EMISdeploymentResponseType> deploymentResponseInspector,
-        Consumer<InputEdiPiOrIcn> guardReserveServiceRequestInspector,
-        Consumer<EMISguardReserveServicePeriodsResponseType> guardReserveServiceResponseInspector,
-        Consumer<String> militaryInformationServiceV2HealthResponseInspector,
-        Consumer<InputEdiPiOrIcn> serviceEpisodesRequestInspector,
-        Consumer<EMISserviceEpisodeResponseType> serviceEpisodesResponseInspector,
-        Consumer<InputEdiPiOrIcn> veteranStatusRequestInspector,
-        Consumer<EMISveteranStatusResponseType> veteranStatusResponseInspector,
-        Consumer<String> veteranStatusServiceV1HealthInspector) {
+    this.config = config;
+    this.sslContext = createSslContext(config.getSsl());
+  }
 
-        this.deploymentRequestInspector = doNothingUnlessSet(deploymentRequestInspector);
-        this.deploymentResponseInspector = doNothingUnlessSet(deploymentResponseInspector);
-        this.guardReserveServiceRequestInspector = doNothingUnlessSet(guardReserveServiceRequestInspector);
-        this.guardReserveServiceResponseInspector = doNothingUnlessSet(guardReserveServiceResponseInspector);
-        this.militaryInformationServiceV2HealthResponseInspector = doNothingUnlessSet(militaryInformationServiceV2HealthResponseInspector);
-        this.serviceEpisodesRequestInspector = doNothingUnlessSet(serviceEpisodesRequestInspector);
-        this.serviceEpisodesResponseInspector = doNothingUnlessSet(serviceEpisodesResponseInspector);
-        this.veteranStatusRequestInspector = doNothingUnlessSet(veteranStatusRequestInspector);
-        this.veteranStatusResponseInspector = doNothingUnlessSet(veteranStatusResponseInspector);
-        this.veteranStatusServiceV1HealthInspector = doNothingUnlessSet(veteranStatusServiceV1HealthInspector);
+  private static <T> Consumer<T> doNothingUnlessSet(Consumer<T> action) {
+    return action == null ? ignored -> {} : action;
+  }
 
-        this.config = config;
-        this.sslContext = createSslContext(config.getSsl());
+  public static SoapEmisClient of(EmisClientConfig config) {
+    return new SoapEmisClient(config, null, null, null, null, null, null, null, null);
+  }
+
+  @SneakyThrows
+  private Optional<SSLContext> createSslContext(EmisClientConfig.Ssl ssl) {
+    if (!ssl.isEnabled()) {
+      return Optional.empty();
     }
-
-    private static <T> Consumer<T> doNothingUnlessSet(Consumer<T> action) {
-        return action == null ? ignored -> {} : action;
+    log.info("Initializing eMIS SSL");
+    try (var inputStream = ResourceUtils.getURL(ssl.getKeyStore().getPath()).openStream()) {
+      var ks = KeyStore.getInstance("JKS");
+      ks.load(inputStream, ssl.getKeyStore().getPassword().toCharArray());
+      var kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+      kmf.init(ks, ssl.getKeyStore().getKeyPassword().toCharArray());
+      var trustStream = ResourceUtils.getURL(ssl.getTrustStore().getPath()).openStream();
+      var ts = KeyStore.getInstance("JKS");
+      ts.load(trustStream, ssl.getTrustStore().getPassword().toCharArray());
+      var tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+      tmf.init(ts);
+      var sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
+      return Optional.of(sslContext);
     }
+  }
 
-    public static SoapEmisClient of(EmisClientConfig config) {
-        return new SoapEmisClient(config, null, null, null, null, null, null, null, null, null, null);
+  @Override
+  public EMISdeploymentResponseType deploymentRequest(
+      gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn ediPiOrIcn) {
+    try {
+      this.deploymentRequestInspector.accept(ediPiOrIcn);
+      var port =
+          port(
+              config.getMilitaryInformationServiceV2(),
+              url ->
+                  new EMISMilitaryInformationSerivcePortTypes_Service(url)
+                      .getEMISMilitaryInformationSerivcePort());
+      var response = port.getDeployment(ediPiOrIcn);
+      this.deploymentResponseInspector.accept(response);
+      return response;
+    } catch (ServerSOAPFaultException e) {
+      log.error("Received invalid response from service: {}", e.getMessage());
+      throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
     }
+  }
 
-    @SneakyThrows
-    private Optional<SSLContext> createSslContext(EmisClientConfig.Ssl ssl) {
-        if (!ssl.isEnabled()) {
-            return Optional.empty();
-        }
-        log.info("Initializing eMIS SSL");
-        try (var inputStream = ResourceUtils.getURL(ssl.getKeyStore().getPath()).openStream()) {
-            var ks = KeyStore.getInstance("JKS");
-            ks.load(inputStream, ssl.getKeyStore().getPassword().toCharArray());
-            var kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            kmf.init(ks, ssl.getKeyStore().getKeyPassword().toCharArray());
-            var trustStream = ResourceUtils.getURL(ssl.getTrustStore().getPath()).openStream();
-            var ts = KeyStore.getInstance("JKS");
-            ts.load(trustStream, ssl.getTrustStore().getPassword().toCharArray());
-            var tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-            tmf.init(ts);
-            var sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
-            return Optional.of(sslContext);
-        }
+  @Override
+  public EMISguardReserveServicePeriodsResponseType guardReserveServiceRequest(
+      gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn ediPiOrIcn) {
+    try {
+      guardReserveServiceRequestInspector.accept(ediPiOrIcn);
+      var port =
+          port(
+              config.getMilitaryInformationServiceV2(),
+              url ->
+                  new EMISMilitaryInformationSerivcePortTypes_Service(url)
+                      .getEMISMilitaryInformationSerivcePort());
+      var response = port.getGuardReserveServicePeriods(ediPiOrIcn);
+      guardReserveServiceResponseInspector.accept(response);
+      return response;
+    } catch (ServerSOAPFaultException e) {
+      log.error("Received invalid response from service: {}", e.getMessage());
+      throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
     }
+  }
 
-    @Override
-    public EMISdeploymentResponseType deploymentRequest(
-        gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn ediPiOrIcn) {
-        try {
-            var port =
-                port(
-                    config.getMilitaryInformationServiceV2(),
-                    url ->
-                        new EMISMilitaryInformationSerivcePortTypes_Service(url)
-                            .getEMISMilitaryInformationSerivcePort());
-            return port.getDeployment(ediPiOrIcn);
-        } catch (ServerSOAPFaultException e) {
-            log.error("Received invalid response from service: {}", e.getMessage());
-            throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
-        }
+  @Override
+  public ResponseEntity<String> militaryInformationServiceV2Health() {
+    try {
+      log.info("militaryInformationServiceV2 health check running...");
+      port(
+          config.getMilitaryInformationServiceV2(),
+          url ->
+              new EMISMilitaryInformationSerivcePortTypes_Service(url)
+                  .getEMISMilitaryInformationSerivcePort());
+      log.info("militaryInformationServiceV2 is healthy");
+    } catch (Exceptions.InaccessibleServiceDefinition | Exceptions.InvalidUrl e) {
+      throw e;
     }
+    return ResponseEntity.ok("Up");
+  }
 
-    @Override
-    public EMISguardReserveServicePeriodsResponseType guardReserveServiceRequest(
-        gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn ediPiOrIcn) {
-        try {
-            var port =
-                port(
-                    config.getMilitaryInformationServiceV2(),
-                    url ->
-                        new EMISMilitaryInformationSerivcePortTypes_Service(url)
-                            .getEMISMilitaryInformationSerivcePort());
-            return port.getGuardReserveServicePeriods(ediPiOrIcn);
-        } catch (ServerSOAPFaultException e) {
-            log.error("Received invalid response from service: {}", e.getMessage());
-            throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
-        }
+  @SneakyThrows
+  private <T> T port(EmisClientConfig.Service svc, Function<URL, T> toPort) {
+    try {
+      T port = toPort.apply(new URL(svc.getWsdl()));
+      final var bindingProvider = ((BindingProvider) port);
+      sslContext.ifPresent(
+          context ->
+              bindingProvider
+                  .getRequestContext()
+                  .put(
+                      "com.sun.xml.ws.transport.https.client.SSLSocketFactory",
+                      context.getSocketFactory()));
+      bindingProvider
+          .getRequestContext()
+          .put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, svc.getUrl());
+
+      bindingProvider
+          .getRequestContext()
+          .put(
+              com.sun.xml.ws.developer.JAXWSProperties.CONNECT_TIMEOUT,
+              (int) config.getConnectionTimeout().toMillis());
+
+      bindingProvider
+          .getRequestContext()
+          .put(
+              com.sun.xml.ws.developer.JAXWSProperties.REQUEST_TIMEOUT,
+              (int) config.getReadTimeout().toMillis());
+
+      return port;
+    } catch (InaccessibleWSDLException e) {
+      log.error("WSDL is inaccessible: {}", e.getMessage());
+      e.getErrors().forEach(t -> log.error("Reason {}", t.getMessage()));
+      throw new Exceptions.InaccessibleServiceDefinition(svc.getWsdl(), e);
+    } catch (MalformedURLException e) {
+      log.error("Failed to create port for {}", svc.getWsdl(), e);
+      throw new Exceptions.InvalidUrl(svc.getWsdl(), e);
     }
+  }
 
-    @Override
-    public ResponseEntity<String> militaryInformationServiceV2Health() {
-        try {
-            port(
-                config.getMilitaryInformationServiceV2(),
-                url ->
-                    new EMISMilitaryInformationSerivcePortTypes_Service(url)
-                        .getEMISMilitaryInformationSerivcePort());
-        } catch (Exceptions.InaccessibleServiceDefinition e) {
-            throw e;
-        } catch (Exceptions.InvalidUrl e) {
-            throw e;
-        }
-        return ResponseEntity.ok("Up");
+  @Override
+  public EMISserviceEpisodeResponseType serviceEpisodesRequest(
+      gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn ediPiOrIcn) {
+    try {
+
+      this.serviceEpisodesRequestInspector.accept(ediPiOrIcn);
+      var port =
+          port(
+              config.getMilitaryInformationServiceV2(),
+              url ->
+                  new EMISMilitaryInformationSerivcePortTypes_Service(url)
+                      .getEMISMilitaryInformationSerivcePort());
+      var response = port.getMilitaryServiceEpisodes(ediPiOrIcn);
+      this.serviceEpisodesResponseInspector.accept(response);
+      return response;
+    } catch (ServerSOAPFaultException e) {
+      log.error("Received invalid response from service: {}", e.getMessage());
+      throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
     }
+  }
 
-    @SneakyThrows
-    private <T> T port(EmisClientConfig.Service svc, Function<URL, T> toPort) {
-        try {
-            T port = toPort.apply(new URL(svc.getWsdl()));
-            final var bindingProvider = ((BindingProvider) port);
-            sslContext.ifPresent(
-                context ->
-                    bindingProvider
-                        .getRequestContext()
-                        .put(
-                            "com.sun.xml.ws.transport.https.client.SSLSocketFactory",
-                            context.getSocketFactory()));
-            bindingProvider
-                .getRequestContext()
-                .put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, svc.getUrl());
-
-            bindingProvider
-                .getRequestContext()
-                .put(
-                    com.sun.xml.ws.developer.JAXWSProperties.CONNECT_TIMEOUT,
-                    (int) config.getConnectionTimeout().toMillis());
-
-            bindingProvider
-                .getRequestContext()
-                .put(
-                    com.sun.xml.ws.developer.JAXWSProperties.REQUEST_TIMEOUT,
-                    (int) config.getReadTimeout().toMillis());
-
-            return port;
-        } catch (InaccessibleWSDLException e) {
-            log.error("WSDL is inaccessible: {}", e.getMessage());
-            e.getErrors().forEach(t -> log.error("Reason {}", t.getMessage()));
-            throw new Exceptions.InaccessibleServiceDefinition(svc.getWsdl(), e);
-        } catch (MalformedURLException e) {
-            log.error("Failed to create port for {}", svc.getWsdl(), e);
-            throw new Exceptions.InvalidUrl(svc.getWsdl(), e);
-        }
+  @Override
+  public EMISveteranStatusResponseType veteranStatusRequest(InputEdiPiOrIcn ediPiOrIcn) {
+    try {
+      this.veteranStatusRequestInspector.accept(ediPiOrIcn);
+      var port =
+          port(
+              config.getVeteranStatusServiceV1(),
+              url ->
+                  new EMISVeteranStatusServicePortTypes_Service(url)
+                      .getEMISVeteranStatusServicePort());
+      var response = port.getVeteranStatus(ediPiOrIcn);
+      this.veteranStatusResponseInspector.accept(response);
+      return response;
+    } catch (ServerSOAPFaultException e) {
+      log.error("Received invalid response from service: {}", e.getMessage());
+      throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
     }
+  }
 
-    @Override
-    public EMISserviceEpisodeResponseType serviceEpisodesRequest(
-        gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn ediPiOrIcn) {
-        try {
-            var port =
-                port(
-                    config.getMilitaryInformationServiceV2(),
-                    url ->
-                        new EMISMilitaryInformationSerivcePortTypes_Service(url)
-                            .getEMISMilitaryInformationSerivcePort());
-            return port.getMilitaryServiceEpisodes(ediPiOrIcn);
-        } catch (ServerSOAPFaultException e) {
-            log.error("Received invalid response from service: {}", e.getMessage());
-            throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
-        }
+  @Override
+  public ResponseEntity<String> veteranStatusServiceV1Health() {
+    try {
+      port(
+          config.getVeteranStatusServiceV1(),
+          url ->
+              new EMISVeteranStatusServicePortTypes_Service(url).getEMISVeteranStatusServicePort());
+    } catch (Exceptions.InaccessibleServiceDefinition e) {
+      throw e;
+    } catch (Exceptions.InvalidUrl e) {
+      throw e;
     }
-
-    @Override
-    public EMISveteranStatusResponseType veteranStatusRequest(InputEdiPiOrIcn ediPiOrIcn) {
-        try {
-            var port =
-                port(
-                    config.getVeteranStatusServiceV1(),
-                    url ->
-                        new EMISVeteranStatusServicePortTypes_Service(url)
-                            .getEMISVeteranStatusServicePort());
-            return port.getVeteranStatus(ediPiOrIcn);
-        } catch (ServerSOAPFaultException e) {
-            log.error("Received invalid response from service: {}", e.getMessage());
-            throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
-        }
-    }
-
-    @Override
-    public ResponseEntity<String> veteranStatusServiceV1Health() {
-        try {
-            port(
-                config.getVeteranStatusServiceV1(),
-                url ->
-                    new EMISVeteranStatusServicePortTypes_Service(url).getEMISVeteranStatusServicePort());
-        } catch (Exceptions.InaccessibleServiceDefinition e) {
-            throw e;
-        } catch (Exceptions.InvalidUrl e) {
-            throw e;
-        }
-        return ResponseEntity.ok("Up");
-    }
+    return ResponseEntity.ok("Up");
+  }
 }

--- a/emis-client/src/main/java/gov/va/api/lighthouse/emis/SoapEmisClient.java
+++ b/emis-client/src/main/java/gov/va/api/lighthouse/emis/SoapEmisClient.java
@@ -9,16 +9,20 @@ import gov.va.viers.cdi.emis.requestresponse.v1.InputEdiPiOrIcn;
 import gov.va.viers.cdi.emis.requestresponse.v2.EMISdeploymentResponseType;
 import gov.va.viers.cdi.emis.requestresponse.v2.EMISguardReserveServicePeriodsResponseType;
 import gov.va.viers.cdi.emis.requestresponse.v2.EMISserviceEpisodeResponseType;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.KeyStore;
 import java.security.SecureRandom;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 import javax.xml.ws.BindingProvider;
+
+import lombok.Builder;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -26,175 +30,253 @@ import org.springframework.util.ResourceUtils;
 
 @Slf4j
 public class SoapEmisClient implements EmisClient {
-  private final Optional<SSLContext> sslContext;
+    private final Optional<SSLContext> sslContext;
 
-  private final EmisClientConfig config;
+    private final EmisClientConfig config;
 
-  private SoapEmisClient(EmisClientConfig config) {
-    this.config = config;
-    this.sslContext = createSslContext(config.getSsl());
-  }
+    /**
+     * Inspect the deployment message before it is sent.
+     */
+    private final Consumer<InputEdiPiOrIcn> deploymentRequestInspector;
 
-  public static SoapEmisClient of(EmisClientConfig config) {
-    return new SoapEmisClient(config);
-  }
+    /**
+     * Inspect the deployment message after it is received.
+     */
+    private final Consumer<EMISdeploymentResponseType> deploymentResponseInspector;
 
-  @SneakyThrows
-  private Optional<SSLContext> createSslContext(EmisClientConfig.Ssl ssl) {
-    if (!ssl.isEnabled()) {
-      return Optional.empty();
+    /**
+     * Inspect the guardReserveService message before it is sent.
+     */
+    private final Consumer<InputEdiPiOrIcn> guardReserveServiceRequestInspector;
+
+    /**
+     * Inspect the guardReserveService message after it is received.
+     */
+    private final Consumer<EMISguardReserveServicePeriodsResponseType> guardReserveServiceResponseInspector;
+
+    /**
+     * Inspect the militaryInformationServiceV2Health message after it is received.
+     */
+    private final Consumer<String> militaryInformationServiceV2HealthResponseInspector;
+
+    /**
+     * Inspect the serviceEpisodes message before it is sent.
+     */
+    private final Consumer<InputEdiPiOrIcn> serviceEpisodesRequestInspector;
+
+    /**
+     * Inspect the serviceEpisodes message after it is received.
+     */
+    private final Consumer<EMISserviceEpisodeResponseType> serviceEpisodesResponseInspector;
+
+    /**
+     * Inspect the veteranStatus message before it is sent.
+     */
+    private final Consumer<InputEdiPiOrIcn> veteranStatusRequestInspector;
+
+    /**
+     * Inspect the veteranStatus message after it is received.
+     */
+    private final Consumer<EMISveteranStatusResponseType> veteranStatusResponseInspector;
+
+    /**
+     * Inspect the veteranStatusServiceV1Health message after it is received.
+     */
+    private final Consumer<String> veteranStatusServiceV1HealthInspector;
+
+    @Builder
+    private SoapEmisClient(
+        EmisClientConfig config,
+        Consumer<InputEdiPiOrIcn> deploymentRequestInspector,
+        Consumer<EMISdeploymentResponseType> deploymentResponseInspector,
+        Consumer<InputEdiPiOrIcn> guardReserveServiceRequestInspector,
+        Consumer<EMISguardReserveServicePeriodsResponseType> guardReserveServiceResponseInspector,
+        Consumer<String> militaryInformationServiceV2HealthResponseInspector,
+        Consumer<InputEdiPiOrIcn> serviceEpisodesRequestInspector,
+        Consumer<EMISserviceEpisodeResponseType> serviceEpisodesResponseInspector,
+        Consumer<InputEdiPiOrIcn> veteranStatusRequestInspector,
+        Consumer<EMISveteranStatusResponseType> veteranStatusResponseInspector,
+        Consumer<String> veteranStatusServiceV1HealthInspector) {
+
+        this.deploymentRequestInspector = doNothingUnlessSet(deploymentRequestInspector);
+        this.deploymentResponseInspector = doNothingUnlessSet(deploymentResponseInspector);
+        this.guardReserveServiceRequestInspector = doNothingUnlessSet(guardReserveServiceRequestInspector);
+        this.guardReserveServiceResponseInspector = doNothingUnlessSet(guardReserveServiceResponseInspector);
+        this.militaryInformationServiceV2HealthResponseInspector = doNothingUnlessSet(militaryInformationServiceV2HealthResponseInspector);
+        this.serviceEpisodesRequestInspector = doNothingUnlessSet(serviceEpisodesRequestInspector);
+        this.serviceEpisodesResponseInspector = doNothingUnlessSet(serviceEpisodesResponseInspector);
+        this.veteranStatusRequestInspector = doNothingUnlessSet(veteranStatusRequestInspector);
+        this.veteranStatusResponseInspector = doNothingUnlessSet(veteranStatusResponseInspector);
+        this.veteranStatusServiceV1HealthInspector = doNothingUnlessSet(veteranStatusServiceV1HealthInspector);
+
+        this.config = config;
+        this.sslContext = createSslContext(config.getSsl());
     }
-    log.info("Initializing eMIS SSL");
-    try (var inputStream = ResourceUtils.getURL(ssl.getKeyStore().getPath()).openStream()) {
-      var ks = KeyStore.getInstance("JKS");
-      ks.load(inputStream, ssl.getKeyStore().getPassword().toCharArray());
-      var kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-      kmf.init(ks, ssl.getKeyStore().getKeyPassword().toCharArray());
-      var trustStream = ResourceUtils.getURL(ssl.getTrustStore().getPath()).openStream();
-      var ts = KeyStore.getInstance("JKS");
-      ts.load(trustStream, ssl.getTrustStore().getPassword().toCharArray());
-      var tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-      tmf.init(ts);
-      var sslContext = SSLContext.getInstance("TLS");
-      sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
-      return Optional.of(sslContext);
+
+    private static <T> Consumer<T> doNothingUnlessSet(Consumer<T> action) {
+        return action == null ? ignored -> {} : action;
     }
-  }
 
-  @Override
-  public EMISdeploymentResponseType deploymentRequest(
-      gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn ediPiOrIcn) {
-    try {
-      var port =
-          port(
-              config.getMilitaryInformationServiceV2(),
-              url ->
-                  new EMISMilitaryInformationSerivcePortTypes_Service(url)
-                      .getEMISMilitaryInformationSerivcePort());
-      return port.getDeployment(ediPiOrIcn);
-    } catch (ServerSOAPFaultException e) {
-      log.error("Received invalid response from service: {}", e.getMessage());
-      throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
+    public static SoapEmisClient of(EmisClientConfig config) {
+        return new SoapEmisClient(config, null, null, null, null, null, null, null, null, null, null);
     }
-  }
 
-  @Override
-  public EMISguardReserveServicePeriodsResponseType guardReserveServiceRequest(
-      gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn ediPiOrIcn) {
-    try {
-      var port =
-          port(
-              config.getMilitaryInformationServiceV2(),
-              url ->
-                  new EMISMilitaryInformationSerivcePortTypes_Service(url)
-                      .getEMISMilitaryInformationSerivcePort());
-      return port.getGuardReserveServicePeriods(ediPiOrIcn);
-    } catch (ServerSOAPFaultException e) {
-      log.error("Received invalid response from service: {}", e.getMessage());
-      throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
+    @SneakyThrows
+    private Optional<SSLContext> createSslContext(EmisClientConfig.Ssl ssl) {
+        if (!ssl.isEnabled()) {
+            return Optional.empty();
+        }
+        log.info("Initializing eMIS SSL");
+        try (var inputStream = ResourceUtils.getURL(ssl.getKeyStore().getPath()).openStream()) {
+            var ks = KeyStore.getInstance("JKS");
+            ks.load(inputStream, ssl.getKeyStore().getPassword().toCharArray());
+            var kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            kmf.init(ks, ssl.getKeyStore().getKeyPassword().toCharArray());
+            var trustStream = ResourceUtils.getURL(ssl.getTrustStore().getPath()).openStream();
+            var ts = KeyStore.getInstance("JKS");
+            ts.load(trustStream, ssl.getTrustStore().getPassword().toCharArray());
+            var tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            tmf.init(ts);
+            var sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
+            return Optional.of(sslContext);
+        }
     }
-  }
 
-  @Override
-  public ResponseEntity<String> militaryInformationServiceV2Health() {
-    try {
-      port(
-          config.getMilitaryInformationServiceV2(),
-          url ->
-              new EMISMilitaryInformationSerivcePortTypes_Service(url)
-                  .getEMISMilitaryInformationSerivcePort());
-    } catch (Exceptions.InaccessibleServiceDefinition e) {
-      throw e;
-    } catch (Exceptions.InvalidUrl e) {
-      throw e;
+    @Override
+    public EMISdeploymentResponseType deploymentRequest(
+        gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn ediPiOrIcn) {
+        try {
+            var port =
+                port(
+                    config.getMilitaryInformationServiceV2(),
+                    url ->
+                        new EMISMilitaryInformationSerivcePortTypes_Service(url)
+                            .getEMISMilitaryInformationSerivcePort());
+            return port.getDeployment(ediPiOrIcn);
+        } catch (ServerSOAPFaultException e) {
+            log.error("Received invalid response from service: {}", e.getMessage());
+            throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
+        }
     }
-    return ResponseEntity.ok("Up");
-  }
 
-  @SneakyThrows
-  private <T> T port(EmisClientConfig.Service svc, Function<URL, T> toPort) {
-    try {
-      T port = toPort.apply(new URL(svc.getWsdl()));
-      final var bindingProvider = ((BindingProvider) port);
-      sslContext.ifPresent(
-          context ->
-              bindingProvider
-                  .getRequestContext()
-                  .put(
-                      "com.sun.xml.ws.transport.https.client.SSLSocketFactory",
-                      context.getSocketFactory()));
-      bindingProvider
-          .getRequestContext()
-          .put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, svc.getUrl());
-
-      bindingProvider
-          .getRequestContext()
-          .put(
-              com.sun.xml.ws.developer.JAXWSProperties.CONNECT_TIMEOUT,
-              (int) config.getConnectionTimeout().toMillis());
-
-      bindingProvider
-          .getRequestContext()
-          .put(
-              com.sun.xml.ws.developer.JAXWSProperties.REQUEST_TIMEOUT,
-              (int) config.getReadTimeout().toMillis());
-
-      return port;
-    } catch (InaccessibleWSDLException e) {
-      log.error("WSDL is inaccessible: {}", e.getMessage());
-      e.getErrors().forEach(t -> log.error("Reason {}", t.getMessage()));
-      throw new Exceptions.InaccessibleServiceDefinition(svc.getWsdl(), e);
-    } catch (MalformedURLException e) {
-      log.error("Failed to create port for {}", svc.getWsdl(), e);
-      throw new Exceptions.InvalidUrl(svc.getWsdl(), e);
+    @Override
+    public EMISguardReserveServicePeriodsResponseType guardReserveServiceRequest(
+        gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn ediPiOrIcn) {
+        try {
+            var port =
+                port(
+                    config.getMilitaryInformationServiceV2(),
+                    url ->
+                        new EMISMilitaryInformationSerivcePortTypes_Service(url)
+                            .getEMISMilitaryInformationSerivcePort());
+            return port.getGuardReserveServicePeriods(ediPiOrIcn);
+        } catch (ServerSOAPFaultException e) {
+            log.error("Received invalid response from service: {}", e.getMessage());
+            throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
+        }
     }
-  }
 
-  @Override
-  public EMISserviceEpisodeResponseType serviceEpisodesRequest(
-      gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn ediPiOrIcn) {
-    try {
-      var port =
-          port(
-              config.getMilitaryInformationServiceV2(),
-              url ->
-                  new EMISMilitaryInformationSerivcePortTypes_Service(url)
-                      .getEMISMilitaryInformationSerivcePort());
-      return port.getMilitaryServiceEpisodes(ediPiOrIcn);
-    } catch (ServerSOAPFaultException e) {
-      log.error("Received invalid response from service: {}", e.getMessage());
-      throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
+    @Override
+    public ResponseEntity<String> militaryInformationServiceV2Health() {
+        try {
+            port(
+                config.getMilitaryInformationServiceV2(),
+                url ->
+                    new EMISMilitaryInformationSerivcePortTypes_Service(url)
+                        .getEMISMilitaryInformationSerivcePort());
+        } catch (Exceptions.InaccessibleServiceDefinition e) {
+            throw e;
+        } catch (Exceptions.InvalidUrl e) {
+            throw e;
+        }
+        return ResponseEntity.ok("Up");
     }
-  }
 
-  @Override
-  public EMISveteranStatusResponseType veteranStatusRequest(InputEdiPiOrIcn ediPiOrIcn) {
-    try {
-      var port =
-          port(
-              config.getVeteranStatusServiceV1(),
-              url ->
-                  new EMISVeteranStatusServicePortTypes_Service(url)
-                      .getEMISVeteranStatusServicePort());
-      return port.getVeteranStatus(ediPiOrIcn);
-    } catch (ServerSOAPFaultException e) {
-      log.error("Received invalid response from service: {}", e.getMessage());
-      throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
-    }
-  }
+    @SneakyThrows
+    private <T> T port(EmisClientConfig.Service svc, Function<URL, T> toPort) {
+        try {
+            T port = toPort.apply(new URL(svc.getWsdl()));
+            final var bindingProvider = ((BindingProvider) port);
+            sslContext.ifPresent(
+                context ->
+                    bindingProvider
+                        .getRequestContext()
+                        .put(
+                            "com.sun.xml.ws.transport.https.client.SSLSocketFactory",
+                            context.getSocketFactory()));
+            bindingProvider
+                .getRequestContext()
+                .put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, svc.getUrl());
 
-  @Override
-  public ResponseEntity<String> veteranStatusServiceV1Health() {
-    try {
-      port(
-          config.getVeteranStatusServiceV1(),
-          url ->
-              new EMISVeteranStatusServicePortTypes_Service(url).getEMISVeteranStatusServicePort());
-    } catch (Exceptions.InaccessibleServiceDefinition e) {
-      throw e;
-    } catch (Exceptions.InvalidUrl e) {
-      throw e;
+            bindingProvider
+                .getRequestContext()
+                .put(
+                    com.sun.xml.ws.developer.JAXWSProperties.CONNECT_TIMEOUT,
+                    (int) config.getConnectionTimeout().toMillis());
+
+            bindingProvider
+                .getRequestContext()
+                .put(
+                    com.sun.xml.ws.developer.JAXWSProperties.REQUEST_TIMEOUT,
+                    (int) config.getReadTimeout().toMillis());
+
+            return port;
+        } catch (InaccessibleWSDLException e) {
+            log.error("WSDL is inaccessible: {}", e.getMessage());
+            e.getErrors().forEach(t -> log.error("Reason {}", t.getMessage()));
+            throw new Exceptions.InaccessibleServiceDefinition(svc.getWsdl(), e);
+        } catch (MalformedURLException e) {
+            log.error("Failed to create port for {}", svc.getWsdl(), e);
+            throw new Exceptions.InvalidUrl(svc.getWsdl(), e);
+        }
     }
-    return ResponseEntity.ok("Up");
-  }
+
+    @Override
+    public EMISserviceEpisodeResponseType serviceEpisodesRequest(
+        gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn ediPiOrIcn) {
+        try {
+            var port =
+                port(
+                    config.getMilitaryInformationServiceV2(),
+                    url ->
+                        new EMISMilitaryInformationSerivcePortTypes_Service(url)
+                            .getEMISMilitaryInformationSerivcePort());
+            return port.getMilitaryServiceEpisodes(ediPiOrIcn);
+        } catch (ServerSOAPFaultException e) {
+            log.error("Received invalid response from service: {}", e.getMessage());
+            throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public EMISveteranStatusResponseType veteranStatusRequest(InputEdiPiOrIcn ediPiOrIcn) {
+        try {
+            var port =
+                port(
+                    config.getVeteranStatusServiceV1(),
+                    url ->
+                        new EMISVeteranStatusServicePortTypes_Service(url)
+                            .getEMISVeteranStatusServicePort());
+            return port.getVeteranStatus(ediPiOrIcn);
+        } catch (ServerSOAPFaultException e) {
+            log.error("Received invalid response from service: {}", e.getMessage());
+            throw new Exceptions.InvalidServiceResponse(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public ResponseEntity<String> veteranStatusServiceV1Health() {
+        try {
+            port(
+                config.getVeteranStatusServiceV1(),
+                url ->
+                    new EMISVeteranStatusServicePortTypes_Service(url).getEMISVeteranStatusServicePort());
+        } catch (Exceptions.InaccessibleServiceDefinition e) {
+            throw e;
+        } catch (Exceptions.InvalidUrl e) {
+            throw e;
+        }
+        return ResponseEntity.ok("Up");
+    }
 }

--- a/emis-client/src/test/java/gov/va/api/lighthouse/emis/MockServerTest.java
+++ b/emis-client/src/test/java/gov/va/api/lighthouse/emis/MockServerTest.java
@@ -5,16 +5,23 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import com.github.tomakehurst.wiremock.matching.UrlPattern;
+import gov.va.viers.cdi.emis.requestresponse.v2.EMISdeploymentResponseType;
+import gov.va.viers.cdi.emis.requestresponse.v2.EMISguardReserveServicePeriodsResponseType;
+import gov.va.viers.cdi.emis.requestresponse.v2.EMISserviceEpisodeResponseType;
 import gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.xml.ws.WebServiceException;
 import lombok.SneakyThrows;
@@ -39,76 +46,89 @@ public class MockServerTest {
   public static void setupWiremock() {
     log.info("setting up wiremock");
     wireMockServer = new WireMockServer(options().dynamicPort().notifier(new Slf4jNotifier(true)));
-    var response =
+    var claimant_response =
         """
-        <env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
-            <env:Header>
-                <NS2:essResponseCode xmlns:NS2="http://va.gov/ess/message/v1">Success</NS2:essResponseCode>
-            </env:Header>
-            <env:Body>
-                <eMISserviceEpisodeResponse xmlns="http://viers.va.gov/cdi/eMIS/RequestResponse/MilitaryInfo/v2"
-                                            xmlns:ns2="http://viers.va.gov/cdi/eMIS/commonService/v2"
-                                            xmlns:ns3="http://viers.va.gov/cdi/eMIS/RequestResponse/v2"
-                                            xmlns:ns4="http://viers.va.gov/cdi/CDI/commonService/v2">
-                    <ns3:militaryServiceEpisode>
-                        <ns2:edipi>1005490754</ns2:edipi>
-                        <ns2:keyData>
-                            <ns2:personnelOrganizationCode>12</ns2:personnelOrganizationCode>
-                            <ns2:personnelCategoryTypeCode>A</ns2:personnelCategoryTypeCode>
-                            <ns2:personnelSegmentIdentifier>1</ns2:personnelSegmentIdentifier>
-                        </ns2:keyData>
-                        <ns2:militaryServiceEpisodeData>
-                            <ns2:serviceEpisodeStartDate>1992-08-26</ns2:serviceEpisodeStartDate>
-                            <ns2:serviceEpisodeEndDate>2017-08-30</ns2:serviceEpisodeEndDate>
-                            <ns2:serviceEpisodeTerminationReason>S</ns2:serviceEpisodeTerminationReason>
-                            <ns2:branchOfServiceCode>F</ns2:branchOfServiceCode>
-                            <ns2:personnelProjectedEndDate>2017-08-31</ns2:personnelProjectedEndDate>
-                            <ns2:personnelProjectedEndDateCertaintyCode>R</ns2:personnelProjectedEndDateCertaintyCode>
-                            <ns2:dischargeCharacterOfServiceCode>A</ns2:dischargeCharacterOfServiceCode>
-                            <ns2:personnelStatusChangeTransactionTypeCode>137</ns2:personnelStatusChangeTransactionTypeCode>
-                            <ns2:narrativeReasonForSeparationCode>033</ns2:narrativeReasonForSeparationCode>
-                            <ns2:narrativeReasonForSeparationTxt>SUFFICIENT SERVICE FOR RETIREMENT
-                            </ns2:narrativeReasonForSeparationTxt>
-                            <ns2:post911GIBillLossCategoryCode>06</ns2:post911GIBillLossCategoryCode>
-                            <ns2:mgadLossCategoryCode>08</ns2:mgadLossCategoryCode>
-                            <ns2:payPlanCode>ME</ns2:payPlanCode>
-                            <ns2:payGradeCode>08</ns2:payGradeCode>
-                            <ns2:serviceRankNameCode>SMSGT</ns2:serviceRankNameCode>
-                            <ns2:serviceRankNameTxt>Senior Master Sergeant</ns2:serviceRankNameTxt>
-                            <ns2:payGradeDate>2014-04-01</ns2:payGradeDate>
-                            <ns2:activeDutyServiceAgreementQuantity>4</ns2:activeDutyServiceAgreementQuantity>
-                            <ns2:uniformServiceInitialEntryDate>1992-05-28</ns2:uniformServiceInitialEntryDate>
-                            <ns2:militaryAccessionSourceCode>00</ns2:militaryAccessionSourceCode>
-                            <ns2:personnelBeginDateSource>7</ns2:personnelBeginDateSource>
-                            <ns2:personnelTerminationDateSourceCode>9</ns2:personnelTerminationDateSourceCode>
-                            <ns2:activeFederalMilitaryServiceBaseDate>1992-08-26</ns2:activeFederalMilitaryServiceBaseDate>
-                            <ns2:mgsrServiceAgreementDurationYearQuantityCode>Z
-                            </ns2:mgsrServiceAgreementDurationYearQuantityCode>
-                            <ns2:reserveUnderAge60Code>W</ns2:reserveUnderAge60Code>
-                        </ns2:militaryServiceEpisodeData>
-                    </ns3:militaryServiceEpisode>
-                </eMISserviceEpisodeResponse>
-            </env:Body>
-        </env:Envelope>
-        """;
+      <env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
+          <env:Header>
+              <NS2:essResponseCode xmlns:NS2="http://va.gov/ess/message/v1">Success</NS2:essResponseCode>
+          </env:Header>
+          <env:Body>
+              <eMISserviceEpisodeResponse xmlns="http://viers.va.gov/cdi/eMIS/RequestResponse/MilitaryInfo/v2"
+                                          xmlns:ns2="http://viers.va.gov/cdi/eMIS/commonService/v2"
+                                          xmlns:ns3="http://viers.va.gov/cdi/eMIS/RequestResponse/v2"
+                                          xmlns:ns4="http://viers.va.gov/cdi/CDI/commonService/v2">
+                  <ns3:militaryServiceEpisode>
+                      <ns2:edipi>1005490754</ns2:edipi>
+                      <ns2:keyData>
+                          <ns2:personnelOrganizationCode>12</ns2:personnelOrganizationCode>
+                          <ns2:personnelCategoryTypeCode>A</ns2:personnelCategoryTypeCode>
+                          <ns2:personnelSegmentIdentifier>1</ns2:personnelSegmentIdentifier>
+                      </ns2:keyData>
+                      <ns2:militaryServiceEpisodeData>
+                          <ns2:serviceEpisodeStartDate>1992-08-26</ns2:serviceEpisodeStartDate>
+                          <ns2:serviceEpisodeEndDate>2017-08-30</ns2:serviceEpisodeEndDate>
+                          <ns2:serviceEpisodeTerminationReason>S</ns2:serviceEpisodeTerminationReason>
+                          <ns2:branchOfServiceCode>F</ns2:branchOfServiceCode>
+                          <ns2:personnelProjectedEndDate>2017-08-31</ns2:personnelProjectedEndDate>
+                          <ns2:personnelProjectedEndDateCertaintyCode>R</ns2:personnelProjectedEndDateCertaintyCode>
+                          <ns2:dischargeCharacterOfServiceCode>A</ns2:dischargeCharacterOfServiceCode>
+                          <ns2:personnelStatusChangeTransactionTypeCode>137</ns2:personnelStatusChangeTransactionTypeCode>
+                          <ns2:narrativeReasonForSeparationCode>033</ns2:narrativeReasonForSeparationCode>
+                          <ns2:narrativeReasonForSeparationTxt>SUFFICIENT SERVICE FOR RETIREMENT
+                          </ns2:narrativeReasonForSeparationTxt>
+                          <ns2:post911GIBillLossCategoryCode>06</ns2:post911GIBillLossCategoryCode>
+                          <ns2:mgadLossCategoryCode>08</ns2:mgadLossCategoryCode>
+                          <ns2:payPlanCode>ME</ns2:payPlanCode>
+                          <ns2:payGradeCode>08</ns2:payGradeCode>
+                          <ns2:serviceRankNameCode>SMSGT</ns2:serviceRankNameCode>
+                          <ns2:serviceRankNameTxt>Senior Master Sergeant</ns2:serviceRankNameTxt>
+                          <ns2:payGradeDate>2014-04-01</ns2:payGradeDate>
+                          <ns2:activeDutyServiceAgreementQuantity>4</ns2:activeDutyServiceAgreementQuantity>
+                          <ns2:uniformServiceInitialEntryDate>1992-05-28</ns2:uniformServiceInitialEntryDate>
+                          <ns2:militaryAccessionSourceCode>00</ns2:militaryAccessionSourceCode>
+                          <ns2:personnelBeginDateSource>7</ns2:personnelBeginDateSource>
+                          <ns2:personnelTerminationDateSourceCode>9</ns2:personnelTerminationDateSourceCode>
+                          <ns2:activeFederalMilitaryServiceBaseDate>1992-08-26</ns2:activeFederalMilitaryServiceBaseDate>
+                          <ns2:mgsrServiceAgreementDurationYearQuantityCode>Z
+                          </ns2:mgsrServiceAgreementDurationYearQuantityCode>
+                          <ns2:reserveUnderAge60Code>W</ns2:reserveUnderAge60Code>
+                      </ns2:militaryServiceEpisodeData>
+                  </ns3:militaryServiceEpisode>
+              </eMISserviceEpisodeResponse>
+          </env:Body>
+      </env:Envelope>
+      """;
     stubRequest(
         wireMockServer,
         WireMock::post,
-        response,
+        claimant_response,
         "/VIERSService/eMIS/v2/MilitaryInformationService",
         Duration.ofSeconds(1));
-
     String claimant_wsdl =
         String.join(
             "",
             Files.readAllLines(
                 Paths.get(
                     "../emis-model/src/main/resources/META-INF/wsdl/v2/eMISMilitaryInformationService.wsdl")));
+
+    String status_wsdl =
+        String.join(
+            "",
+            Files.readAllLines(
+                Paths.get(
+                    "../emis-model/src/main/resources/META-INF/wsdl/v1/eMISVeteranStatusService.wsdl")));
     stubRequest(
         wireMockServer,
         WireMock::get,
         claimant_wsdl,
         "/VIERSService/eMIS/v2/MilitaryInformationService.wsdl",
+        Duration.ZERO);
+
+    stubRequest(
+        wireMockServer,
+        WireMock::get,
+        status_wsdl,
+        "/VIERSService/eMIS/v1/VeteranStatusService.wsdl",
         Duration.ZERO);
     wireMockServer.start();
   }
@@ -127,6 +147,17 @@ public class MockServerTest {
 
   private EmisClientConfig getBaseConfig(Duration connectionTimeout, Duration readTimeout) {
     return EmisClientConfig.builder()
+        .veteranStatusServiceV1(
+            EmisClientConfig.Service.builder()
+                .url(
+                    "http://localhost:"
+                        + wireMockServer.port()
+                        + "/VIERSService/eMIS/v1/VeteranStatusService")
+                .wsdl(
+                    "http://localhost:"
+                        + wireMockServer.port()
+                        + "/VIERSService/eMIS/v1/VeteranStatusService.wsdl")
+                .build())
         .militaryInformationServiceV2(
             EmisClientConfig.Service.builder()
                 .url(
@@ -156,6 +187,44 @@ public class MockServerTest {
         .connectionTimeout(connectionTimeout)
         .readTimeout(readTimeout)
         .build();
+  }
+
+  @Test
+  public void testThatInspectorsAreHit() {
+    Consumer<InputEdiPiOrIcn> deploymentRequestInspector = mock(Consumer.class);
+    Consumer<EMISdeploymentResponseType> deploymentResponseInspector = mock(Consumer.class);
+    Consumer<gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn>
+        guardReserveServiceRequestInspector = mock(Consumer.class);
+    Consumer<EMISguardReserveServicePeriodsResponseType> guardReserveServiceResponseInspector =
+        mock(Consumer.class);
+    Consumer<gov.va.viers.cdi.emis.requestresponse.v2.InputEdiPiOrIcn>
+        serviceEpisodesRequestInspector = mock(Consumer.class);
+    Consumer<EMISserviceEpisodeResponseType> serviceEpisodesResponseInspector =
+        mock(Consumer.class);
+
+    var config = getBaseConfig(Duration.ofSeconds(10), Duration.ofSeconds(10));
+    SoapEmisClient client =
+        SoapEmisClient.builder()
+            .deploymentRequestInspector(deploymentRequestInspector)
+            .deploymentResponseInspector(deploymentResponseInspector)
+            .guardReserveServiceRequestInspector(guardReserveServiceRequestInspector)
+            .guardReserveServiceResponseInspector(guardReserveServiceResponseInspector)
+            .serviceEpisodesRequestInspector(serviceEpisodesRequestInspector)
+            .serviceEpisodesResponseInspector(serviceEpisodesResponseInspector)
+            .config(config)
+            .build();
+    var request = InputEdiPiOrIcn.builder().build();
+    client.deploymentRequest(request);
+    verify(deploymentRequestInspector).accept(any());
+    verify(deploymentResponseInspector).accept(any());
+
+    client.guardReserveServiceRequest(request);
+    verify(guardReserveServiceRequestInspector).accept(any());
+    verify(guardReserveServiceResponseInspector).accept(any());
+
+    client.serviceEpisodesRequest(request);
+    verify(serviceEpisodesRequestInspector).accept(any());
+    verify(serviceEpisodesResponseInspector).accept(any());
   }
 
   @Test

--- a/emis-model/pom.xml
+++ b/emis-model/pom.xml
@@ -17,7 +17,7 @@
     <jacoco.skip>true</jacoco.skip>
     <jaxws-maven-plugin.version>2.6.2</jaxws-maven-plugin.version>
     <jaxws-rt.version>2.3.2</jaxws-rt.version>
-    <lombok-xjc-plugin.version>1.0.4</lombok-xjc-plugin.version>
+    <lombok-xjc-plugin.version>1.0.8</lombok-xjc-plugin.version>
     <spotbugs.skip>true</spotbugs.skip>
     <jarranger.skip>true</jarranger.skip>
     <fmt.skip>true</fmt.skip>


### PR DESCRIPTION
Addresses [API-23234](https://vajira.max.gov/browse/API-23234)

- adds the ability of whoever is using this library to inject a consumer function that can do things like log requests & responses
- by default, if microservice doesn't want to use this feature, they don't have to: default consumer does nothing.
- used in veteran verification for the purpose of logging encrypted request and response bodies whenever an upstream call is made (this is for triaging purposes incase there's some error that we need to trace)
- More details about why I'm doing this can be found in this slack message: https://libertyits.slack.com/archives/C01C68YU88L/p1674581788614219
- More details about how an actually good implementation of this was suggested by Shank folks over my awful initial implementation can be found here: https://libertyits.slack.com/archives/C014R5Y1RDX/p1675200611832449